### PR TITLE
 Adicionar variável reservada ValStr (HCM) - permite configurar texto de elemento

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "lsp-workspace",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "workspaces": [
         "packages/*"
       ],

--- a/packages/compiler/src/internals/data/hcm-internals.json
+++ b/packages/compiler/src/internals/data/hcm-internals.json
@@ -10618,5 +10618,14 @@
     "docUrl": "https://documentacao.senior.com.br/gestao-de-pessoas-hcm/6.10.4/customizacoes/variaveis/turche.htm",
     "docVersion": "6.10.4",
     "documentation": "Turno da chefia encontrado pelas funções BusCadChefe e BusCadChefeLocal."
+  },
+  {
+    "label": "ValStr",
+    "kind": "variable",
+    "isConst": false,
+    "dataType": "Alfa",
+    "documentation": "Variável reservada usada apenas no gerador de relatórios, para alterar a descrição de um campo tipo Descrição. O texto passado para ValStr será impresso no lugar da descrição original do campo.",
+    "docUrl": "https://documentacao.senior.com.br/gestao-de-pessoas-hcm/6.10.4/index.htm#rubi/palavras_reservadas.htm",
+    "docVersion": "6.10.4"
   }
 ]

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -2,10 +2,13 @@
 
 Alterações realizadas na extensão.
 
+## [2.0.5] - 11/06/2026
+### Novidades
+  - Adicionar documentação da variável reservada `ValStr`
+
 ## [2.0.4] - 01/06/2026
 ### Novidades
   - Adicionar documentação da função `CalculaDias`
-  - Adicionar documentação da variável reservada `ValStr`
 
 ## [2.0.3] - 28/05/2026
 ### Atualizar

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -5,6 +5,7 @@ Alterações realizadas na extensão.
 ## [2.0.4] - 01/06/2026
 ### Novidades
   - Adicionar documentação da função `CalculaDias`
+  - Adicionar documentação da variável reservada `ValStr`
 
 ## [2.0.3] - 28/05/2026
 ### Atualizar


### PR DESCRIPTION
Adiciona a variável reservada **`ValStr`** ao registro HCM (datatype: Alfa)e inclui entrada no _CHANGELOG_. **`ValStr`** representa o próprio elemento em edições e permite atribuições como `ValStr = "Texto que eu quero que apareça"`. É _`case-insensitive`_ e não causa breaking changes.

Arquivos alterados:

 - packages/compiler/src/internals/data/hcm-internals.json - nova entrada **`ValStr`**
 - packages/extension/CHANGELOG.md - registro da mudança
