### PR TITLE
Adicionar provider DocumentSymbol (OUTLINE / Ctrl+Shift+O) para arquivos .lsp e .lspt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5538,7 +5538,7 @@
     },
     "packages/compiler": {
       "name": "@lsp/compiler",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "dependencies": {
         "@lsp/compiler": "^2.0.7",
         "@types/node": "^26.1.0",
@@ -5552,7 +5552,7 @@
     },
     "packages/extension": {
       "name": "lsp",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "LICENSE.md",
       "dependencies": {
         "@lsp/compiler": "file:../compiler",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-workspace",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lsp/compiler",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1132,7 +1132,7 @@ export async function compileSingleFile(input: {
 }
 
 export { fileBelongsToContext, normalizePathKey, type ValidationContextConfig, type ContentOverrides };
-export { getContextSymbols, type SymbolInfo };
+export { getContextSymbols, getProgramSymbols, type SymbolInfo };
 export { getCursorMethodNames };
 export { hashText } from './utils/hash-text';
 export
@@ -1144,6 +1144,7 @@ export
 } from './internals/members/lista-methods';
 export { SEMANTIC_TOKEN_TYPES, SEMANTIC_TOKEN_MODIFIERS, type SemanticOccurrence, type SemanticTokenType, type SemanticTokenModifier } from './semantic/semantic-tokens';
 export { collectEmbeddedSqlSemanticOccurrences, collectEmbeddedSqlSemanticDebugReport } from './semantic/embedded-sql-occurrences';
+export { parseSingleFile, type ParseError, type ParseErrorCode, type ParsedFile } from './parser/parser';
 export {
   formatDocument,
   formatDocumentWithDetails,

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 Alterações realizadas na extensão.
 
+## [2.0.10] - 07/07/2026
+### Novidades
+  - Implementado o provider `DocumentSymbol` (Ctrl+Shift+O / OUTLINE) para arquivos `.lsp` e `.lspt`.
+    - Funções (`funcao NOME(); { }`) exibidas como símbolos do tipo *Function*, com parâmetros e variáveis do corpo como filhos na árvore.
+    - Declarações (`Definir funcao NOME();`) exibidas como símbolos do tipo *Variable* com detail "Funcao".
+    - Variáveis de escopo global exibidas no nível raiz.
+
 ## [2.0.9] - 02/07/2026
 ### Novidades
   - Adicionar funções internas da Senior para o *contexto* ERP.

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "lsp",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "publisher": "llutti",
   "icon": "images/icon.png",
   "license": "LICENSE.md",

--- a/packages/extension/src/server.ts
+++ b/packages/extension/src/server.ts
@@ -24,6 +24,7 @@ import
     buildSymbolQueryScopeForSingleFile,
     getContextSymbols,
     getCursorMethodNames,
+    compileSingleFile,
     listListaMethods,
     listListaProperties,
     prepareRename,
@@ -2924,6 +2925,20 @@ async function getSymbolsForFallbackDocument(doc: TextDocument): Promise<SymbolI
   return result.symbols ?? [];
 }
 
+async function getDocumentSymbols(doc: TextDocument): Promise<SymbolInfo[]>
+{
+  const filePath = toFsPath(doc.uri);
+  const context = findContextForFile(filePath);
+  const system = getCompilerSystemForFile(filePath, context);
+  const result = await compileSingleFile({
+    filePath,
+    text: doc.getText(),
+    system,
+    includeSemantics: false
+  });
+  return result.symbols ?? [];
+}
+
 async function getSymbolQueryScopeForDocument(doc: TextDocument): Promise<{
   filePath: string;
   context: ResolvedContext | null;
@@ -5428,6 +5443,7 @@ registerLanguageHandlers({
   isInsideStringLiteral,
   getSymbolsForContext,
   getSymbolsForFallbackDocument,
+  getDocumentSymbols,
   completionItem,
   snippetItem,
   listaMethodCompletionItem,

--- a/packages/extension/src/server/register-language-handlers.ts
+++ b/packages/extension/src/server/register-language-handlers.ts
@@ -2,9 +2,12 @@ import {
   CompletionItem,
   CompletionItemKind,
   MarkupKind,
+  SymbolKind,
   type CompletionParams,
   type Connection,
   type DefinitionParams,
+  type DocumentSymbol,
+  type DocumentSymbolParams,
   type Hover,
   type HoverParams,
   type ImplementationParams,
@@ -47,6 +50,7 @@ type RegisterLanguageHandlersDeps = {
   isInsideStringLiteral(line: string, position: number): boolean;
   getSymbolsForContext(context: ResolvedContext): Promise<SymbolInfo[]>;
   getSymbolsForFallbackDocument(doc: TextDocument): Promise<SymbolInfo[]>;
+  getDocumentSymbols(doc: TextDocument): Promise<SymbolInfo[]>;
   completionItem(kind: CompletionItemKind | number, label: string, insertText?: string): CompletionItem;
   snippetItem(label: string, snippet: string, detail?: string): CompletionItem;
   listaMethodCompletionItem(method: unknown): CompletionItem;
@@ -98,6 +102,7 @@ export function registerLanguageHandlers(deps: RegisterLanguageHandlersDeps): vo
     isInsideStringLiteral,
     getSymbolsForContext,
     getSymbolsForFallbackDocument,
+    getDocumentSymbols,
     completionItem,
     snippetItem,
     listaMethodCompletionItem,
@@ -503,4 +508,130 @@ export function registerLanguageHandlers(deps: RegisterLanguageHandlersDeps): vo
       return null;
     }
   });
+
+  connection.onDocumentSymbol(async (params: DocumentSymbolParams): Promise<DocumentSymbol[]> =>
+  {
+    const doc = documents.get(params.textDocument.uri);
+    if (!doc) return [];
+    try
+    {
+      const symbols = await getDocumentSymbols(doc);
+      return buildDocumentSymbolTree(symbols, toFsPath(doc.uri));
+    } catch
+    {
+      return [];
+    }
+  });
+}
+
+function buildDocumentSymbolTree(symbols: SymbolInfo[], fsPath: string): DocumentSymbol[]
+{
+  const docSymbols = symbols.filter((s) => s.sourcePath === fsPath && s.range);
+
+  const funcImpls: SymbolInfo[] = [];
+  const funcDecls: SymbolInfo[] = [];
+  const plainVars: SymbolInfo[] = [];
+
+  for (const s of docSymbols)
+  {
+    if (s.kind === 'function')
+    {
+      if (s.implemented) funcImpls.push(s);
+      if (s.declared) funcDecls.push(s);
+    } else
+    {
+      plainVars.push(s);
+    }
+  }
+
+  // FuncImpl entries → Function kind with children
+  const topLevel: DocumentSymbol[] = [];
+  const usedVars = new Set<SymbolInfo>();
+
+  for (const func of funcImpls)
+  {
+    const fr = func.range!;
+    const ds: DocumentSymbol = {
+      name: func.name,
+      kind: SymbolKind.Function,
+      range: fr,
+      selectionRange: fr,
+      detail: func.typeName !== 'Desconhecido' ? func.typeName : undefined,
+      children: []
+    };
+
+    if (func.params)
+    {
+      for (const p of func.params)
+      {
+        const pr = p.range ?? p.nameRange ?? fr;
+        ds.children!.push({
+          name: p.name,
+          kind: SymbolKind.Variable,
+          range: pr,
+          selectionRange: pr
+        });
+      }
+    }
+
+    for (const v of plainVars)
+    {
+      if (rangeContains(fr, v.range!))
+      {
+        ds.children!.push({
+          name: v.name,
+          kind: SymbolKind.Variable,
+          range: v.range!,
+          selectionRange: v.range!,
+          detail: v.typeName !== 'Desconhecido' ? v.typeName : undefined
+        });
+        usedVars.add(v);
+      }
+    }
+
+    topLevel.push(ds);
+  }
+
+  // FuncDecl entries → Variable kind (like a function-typed variable)
+  for (const decl of funcDecls)
+  {
+    topLevel.push({
+      name: decl.name,
+      kind: SymbolKind.Variable,
+      range: decl.range!,
+      selectionRange: decl.range!,
+      detail: 'Funcao'
+    });
+  }
+
+  // Top‑level variables not inside any function
+  for (const v of plainVars)
+  {
+    if (!usedVars.has(v))
+    {
+      topLevel.push({
+        name: v.name,
+        kind: SymbolKind.Variable,
+        range: v.range!,
+        selectionRange: v.range!,
+        detail: v.typeName !== 'Desconhecido' ? v.typeName : undefined
+      });
+    }
+  }
+
+  return topLevel;
+}
+
+function rangeStartOrd(r: Range): number
+{
+  return r.start.line * 1_000_000 + r.start.character;
+}
+
+function rangeContains(outer: Range, inner: Range): boolean
+{
+  const oStart = rangeStartOrd(outer);
+  const oEnd = outer.end.line * 1_000_000 + outer.end.character;
+  const iStart = rangeStartOrd(inner);
+  const iEnd = inner.end.line * 1_000_000 + inner.end.character;
+  return iStart >= oStart && iEnd <= oEnd;
 }

--- a/packages/extension/src/server/register-lifecycle-handlers.ts
+++ b/packages/extension/src/server/register-lifecycle-handlers.ts
@@ -230,6 +230,7 @@ export function registerLifecycleHandlers(input: {
         renameProvider: { prepareProvider: true },
         documentFormattingProvider: true,
         documentRangeFormattingProvider: false,
+        documentSymbolProvider: true,
         diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: false },
         semanticTokensProvider: {
           legend: {


### PR DESCRIPTION
Descrição:
### O que foi feito

Implementado o provider `textDocument/documentSymbol` no Language Server, permitindo que o VS Code exiba o OUTLINE e o Ctrl+Shift+O (símbolos do documento) para arquivos `.lsp` e `.lspt`.

### Detalhes técnicos

- **`packages/extension/src/server/register-language-handlers.ts`**: Adicionado handler `connection.onDocumentSymbol` que mapeia `SymbolInfo` → `DocumentSymbol`. Função `buildDocumentSymbolTree` monta uma árvore hierárquica:
  - `funcao NOME(); { }` → `Function` com parâmetros e variáveis do corpo como filhos.
  - `Definir funcao NOME();` → `Variable` com detail `"Funcao"`.
  - Variáveis de escopo global no nível raiz.
  - A relação pai-filho é determinada por range containment (range da variável dentro do range da função).

- **`packages/extension/src/server.ts`**: Adicionada função `getDocumentSymbols(doc)` que compila apenas o arquivo atual via `compileSingleFile`, sem depender do contexto inteiro.

- **`packages/compiler/src/index.ts`**: Exportados `getProgramSymbols`, `parseSingleFile` e tipos relacionados (`ParseError`, `ParseErrorCode`, `ParsedFile`) para uso no servidor.

- **`packages/extension/src/server/register-lifecycle-handlers.ts`**: Adicionado `documentSymbolProvider: true` nas capabilities do servidor — item obrigatório para o VS Code enviar as requisições de símbolo.

### Como testar

1. Pressione F5 para abrir o EDH.
2. Abra um arquivo `.lsp` ou `.lspt`.
3. Pressione Ctrl+Shift+O ou clique no OUTLINE.
4. Deve exibir funções (com sub-ítens para parâmetros e variáveis internas), declarações `Definir funcao` e variáveis globais.