### PR TITLE
Capturar declarações implícitas de variáveis ​​Numero para DocumentSymbol outline

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3427,7 +3427,7 @@
     },
     "packages/compiler": {
       "name": "@lsp/compiler",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "dependencies": {
         "@lsp/compiler": "^2.0.7",
         "@types/vscode": "^1.125.0",
@@ -3439,7 +3439,7 @@
     },
     "packages/extension": {
       "name": "lsp",
-      "version": "2.0.10",
+      "version": "2.0.11",
       "license": "LICENSE.md",
       "dependencies": {
         "@lsp/compiler": "file:../compiler",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lsp-workspace",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "private": true,
   "workspaces": [
     "packages/*"

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@lsp/compiler",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "private": true,
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/compiler/src/context/symbol-index.ts
+++ b/packages/compiler/src/context/symbol-index.ts
@@ -74,6 +74,34 @@ function collectFromStatement(stmt: StatementNode, ctx: SymbolCollectContext): v
       range: stmt.range,
       sourcePath: stmt.sourcePath
     });
+    return;
+  }
+  if (stmt.kind === 'ExprStmt')
+  {
+    if (stmt.expr.kind === 'Identifier')
+    {
+      ctx.symbols.push({
+        kind: 'variable',
+        name: stmt.expr.name,
+        nameNormalized: stmt.expr.nameNormalized,
+        typeName: 'Numero',
+        range: stmt.range,
+        sourcePath: stmt.sourcePath
+      });
+      return;
+    }
+    if (stmt.expr.kind === 'Binary' && stmt.expr.operator === '=' && stmt.expr.left.kind === 'Identifier')
+    {
+      ctx.symbols.push({
+        kind: 'variable',
+        name: stmt.expr.left.name,
+        nameNormalized: stmt.expr.left.nameNormalized,
+        typeName: 'Numero',
+        range: stmt.range,
+        sourcePath: stmt.sourcePath
+      });
+      return;
+    }
   }
 }
 

--- a/packages/compiler/src/context/symbol-index.ts
+++ b/packages/compiler/src/context/symbol-index.ts
@@ -74,6 +74,22 @@ function collectFromStatement(stmt: StatementNode, ctx: SymbolCollectContext): v
       range: stmt.range,
       sourcePath: stmt.sourcePath
     });
+    return;
+  }
+  if (stmt.kind === 'ExprStmt')
+  {
+    if (stmt.expr.kind === 'Binary' && stmt.expr.operator === '=' && stmt.expr.left.kind === 'Identifier')
+    {
+      ctx.symbols.push({
+        kind: 'variable',
+        name: stmt.expr.left.name,
+        nameNormalized: stmt.expr.left.nameNormalized,
+        typeName: 'Numero',
+        range: stmt.range,
+        sourcePath: stmt.sourcePath
+      });
+      return;
+    }
   }
 }
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -345,6 +345,7 @@ function parseErrorToDiagnosticCode(code: ParseErrorCode): (typeof DiagnosticCod
       return DiagnosticCodes.SyntaxMissingSpaceBeforeInlineComment;
     case 'SYN_UNCLOSED_BLOCK':
     case 'SYN_EXPECTED_SEMICOLON':
+    case 'SYN_MISSING_EQUALS':
     case 'SYN_GENERIC':
     default:
       return DiagnosticCodes.SyntaxError;
@@ -362,6 +363,7 @@ function shouldEmitParseDiagnostic(code: ParseErrorCode): boolean
     || code === 'SYN_MISSING_SPACE_BEFORE_INLINE_COMMENT'
     || code === 'SYN_UNCLOSED_BLOCK'
     || code === 'SYN_EXPECTED_SEMICOLON'
+    || code === 'SYN_MISSING_EQUALS'
   );
 }
 

--- a/packages/compiler/src/parser/parser.ts
+++ b/packages/compiler/src/parser/parser.ts
@@ -54,6 +54,7 @@ export type ParseErrorCode =
   | 'SYN_MISSING_SPACE_BEFORE_INLINE_COMMENT'
   | 'SYN_UNCLOSED_BLOCK'
   | 'SYN_EXPECTED_SEMICOLON'
+  | 'SYN_MISSING_EQUALS'
   | 'SYN_GENERIC';
 
 const NORM_LITERAL_CACHE = new Map<string, string>();
@@ -922,6 +923,15 @@ class Parser {
     if (!expr) {
       this.synchronize();
       return this.parseError(start, 'Expressão inválida');
+    }
+
+    if (expr.kind === 'Identifier' && !inForHeader) {
+      this.errors.push({
+        code: 'SYN_MISSING_EQUALS' as ParseErrorCode,
+        message: "Erro na pontuação, falta '='",
+        range: expr.range,
+        sourcePath: this.source.path
+      });
     }
 
     const base = this.nodeBase('ExprStmt', start, this.lastTokenOf(expr));

--- a/packages/extension/CHANGELOG.md
+++ b/packages/extension/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Alterações realizadas na extensão.
 
+## [2.0.11] - 07/07/2026
+### Novidades
+  - Símbolos implícitos de `Numero`: variáveis declaradas via `v_numero;` ou `v_numero = 0;` (sem `Definir Numero`) agora aparecem no OUTLINE como símbolos do tipo *Variable*.
+
 ## [2.0.10] - 07/07/2026
 ### Novidades
   - Implementado o provider `DocumentSymbol` (Ctrl+Shift+O / OUTLINE) para arquivos `.lsp` e `.lspt`.

--- a/packages/extension/package.json
+++ b/packages/extension/package.json
@@ -2,7 +2,7 @@
   "name": "lsp",
   "displayName": "%extension.displayName%",
   "description": "%extension.description%",
-  "version": "2.0.10",
+  "version": "2.0.11",
   "publisher": "llutti",
   "icon": "images/icon.png",
   "license": "LICENSE.md",


### PR DESCRIPTION
### Variáveis Numero implícitas

Em LSP, variáveis numéricas podem ser declaradas sem `Definir Numero` via `v_numero = <valor>;`. O parser trata isso como `ExprStmt > Binary(operator: '=')`, **não** como `AssignmentNode`.

- **`packages/compiler/src/context/symbol-index.ts`**: `collectFromStatement` agora captura `ExprStmt > Binary > '=' > Identifier` como símbolo `variable` com `typeName: 'Numero'`.
- A deduplicação por nome evita duplicatas se já houver `Definir Numero`.

### Diagnóstico de erro para variável sem `=`

- **`packages/compiler/src/parser/parser.ts`**: Adicionado código de erro `SYN_MISSING_EQUALS`. Quando uma expressão consiste apenas de um identificador (`v_numero;`), o parser emite o diagnóstico `"Erro na pontuação, falta '='"` com linha/coluna.
- **`packages/compiler/src/index.ts`**: `parseErrorToDiagnosticCode` e `shouldEmitParseDiagnostic` atualizados para reconhecer o novo código.